### PR TITLE
config sshd error

### DIFF
--- a/recipes/ssh.rb
+++ b/recipes/ssh.rb
@@ -33,12 +33,13 @@ execute 'Stop sshd' do
     only_if 'cygrunsrv -Q sshd'
 end
 
-execute 'Configure sshd service' do
-    cwd 'C:\cygwin\bin'
-    environment ({'PATH' => '$PATH:.:/cygdrive/c/cygwin/bin'})
-    command "bash /usr/bin/ssh-host-config --yes --cygwin \"ntsec\" --user #{node['cygwin']['ssh']['sshd_user']} --pwd \"#{node['cygwin']['ssh']['sshd_passwd']}\" "
-    not_if('cygrunsrv -Q sshd').include? 'Running' 
-end
+# Can ypu please look at eh below scrip as it is throwing an error when trying to execute the congiure sshd part 
+# execute 'Configure sshd service' do
+#     cwd 'C:\cygwin\bin'
+#     environment ({'PATH' => '$PATH:.:/cygdrive/c/cygwin/bin'})
+#     command "bash /usr/bin/ssh-host-config --yes --cygwin \"ntsec\" --user #{node['cygwin']['ssh']['sshd_user']} --pwd \"#{node['cygwin']['ssh']['sshd_passwd']}\" "
+#     not_if('cygrunsrv -Q sshd').include? 'Running' 
+# end
 
 execute 'Make sure the password does not expire' do
     command  "net user #{node['cygwin']['ssh']['sshd_user']} /expires:never /active:yes"


### PR DESCRIPTION


Hi, I am getting the below error when trying to run the cygwin cookbook by chef via packer for building a aws-windows dotnetcore template. I beleive this is due to an ancient Cygwin bug in the ssh-host-config script. Could ypu please help me with this

the error is shown below.
   amazon-ebs:     ================================================================================
2017/11/16 11:14:19 ui:     amazon-ebs:     Error executing action `run` on resource 'execute[Configure sshd service]'
    amazon-ebs:     Error executing action `run` on resource 'execute[Configure sshd service]'
2017/11/16 11:14:19 ui:     amazon-ebs:     ================================================================================